### PR TITLE
feat: add Gingiris open source growth playbooks to 产品发布 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,10 @@
 -   [High Paying Affiliate Programs](https://highpayingaffiliateprograms.com/) - 帮助市场人员在推广这些项目, 佣金基本上都是 30% 以上
 -   [Product Hunt 冲榜前三攻略](https://mp.weixin.qq.com/s/Nlth1disb61qyK722x5C_A)
 -   [310 个网站小众点的网站宣传自己的产品](https://x.com/lxfater/status/1866339428773572992)
-
+-   [Gingiris AI 产品发布 Playbook](https://github.com/Gingiris/gingiris-launch) - 基于 30+ 次 Product Hunt #1 经验的完整发布 SOP，含 KOL 外联、Reddit 营销、UGC 制作模板，完全免费开源
+-   [Gingiris 开源项目增长 Playbook](https://github.com/Gingiris/gingiris-opensource) - 从 0 到 60k+ GitHub Star 的完整操盘手册，覆盖 HN、Reddit、V2EX 等全渠道推广策略
+-   [Gingiris B2B SaaS 增长 Playbook](https://github.com/Gingiris/gingiris-b2b-growth) - 从 PMF 到 $10M ARR 的完整增长框架，含 PLG/SLG/渠道合作策略和可直接使用的模板
+-   [Gingiris ASO & App 冷启动 Playbook](https://github.com/Gingiris/gingiris-aso-growth) - App Store 和 Google Play 关键词优化、元数据策略与冷启动用户获取完整指南
 ### Logo 设计
 
 -   [favicon generator 1](https://realfavicongenerator.net/) - 生成多平台多种类 logo(ico、PNG、SVG)


### PR DESCRIPTION
## 新增工具

根据 Issue #12 中 @yaolifeng0629 的建议，通过 PR 方式提交收录申请。

在「产品发布」分类下新增 4 个完全免费开源的增长方法论 Playbook：

- **[Gingiris AI 产品发布 Playbook](https://github.com/Gingiris/gingiris-launch)** - 基于 30+ 次 Product Hunt #1 经验的完整发布 SOP，含 KOL 外联、Reddit 营销、UGC 制作模板
- **[Gingiris 开源项目增长 Playbook](https://github.com/Gingiris/gingiris-opensource)** - 从 0 到 60k+ GitHub Star 的完整操盘手册，覆盖 HN、Reddit、V2EX 等全渠道推广策略
- **[Gingiris B2B SaaS 增长 Playbook](https://github.com/Gingiris/gingiris-b2b-growth)** - 从 PMF 到 $10M ARR 的完整增长框架，含 PLG/SLG/渠道合作策略和可直接使用的模板
- **[Gingiris ASO & App 冷启动 Playbook](https://github.com/Gingiris/gingiris-aso-growth)** - App Store 和 Google Play 关键词优化、元数据策略与冷启动用户获取完整指南

这些 Playbook 均为实战经验总结，完全免费开源，适合独立开发者和出海团队直接使用。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add four Gingiris open-source growth playbooks to the 产品发布 section to give practical, step-by-step guides for launches, open-source growth, B2B SaaS, and ASO.

- **New Features**
  - Gingiris AI 产品发布 Playbook: https://github.com/Gingiris/gingiris-launch — complete launch SOP with KOL outreach, Reddit, UGC.
  - Gingiris 开源项目增长 Playbook: https://github.com/Gingiris/gingiris-opensource — strategies from 0→60k+ GitHub stars across HN/Reddit/V2EX.
  - Gingiris B2B SaaS 增长 Playbook: https://github.com/Gingiris/gingiris-b2b-growth — PMF→$10M ARR with PLG/SLG/partner playbooks.
  - Gingiris ASO & App 冷启动 Playbook: https://github.com/Gingiris/gingiris-aso-growth — App Store/Google Play ASO and cold-start guides.

<sup>Written for commit c4be6707f6b1b89bf60997da85807d6093041e0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

