### PR TITLE
Add Drevon - Mac GTM AI agent app

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
     -   [短链或长链](#短链或长链)
     -   [信息渠道](#信息渠道)
     -   [产品发布](#产品发布)
+- [Drevon](https://drevon.dev) - Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot.
     -   [Logo 设计](#logo设计)
     -   [项目管理](#项目管理)
     -   [其他工具](#其他工具)


### PR DESCRIPTION
Adding Drevon (https://drevon.dev) - Mac desktop workspace for GTM engineers running parallel AI agents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Drevon to the README tools list: a Mac desktop workspace for GTM engineers to run parallel AI agents (Claude Code, Codex, or Copilot).

<sup>Written for commit 037d766712ba128f72141e05ac83c5bab790469f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

