### PR TITLE
Add Bernstein to AI Resources / AI 资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@
 ### AI 资源
 
 -   [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
+-   [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
 
 ### 其他工具
 

--- a/README_en.md
+++ b/README_en.md
@@ -403,6 +403,10 @@ Collect the latest and most practical free tools and resources in the field of i
 -   [Trello](https://trello.com/) - A flexible visual project management tool.
 -   [Notion](https://www.notion.so/) - A workspace integrating notes, documents, and task management.
 
+### AI Resources
+
+-   [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0, open-source/self-hosted) Multi-agent orchestrator that runs Claude Code, Codex CLI, Gemini CLI, OpenHands, Cursor, Aider, and 31 other CLI coding agents in parallel git worktrees. Deterministic Python scheduler, file-based state, MCP server, quality gates, cost tracking.
+
 ### Other Tools
 
 -   [Black Apple Software Park](https://mackext.com/)


### PR DESCRIPTION
Adds [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) to the `AI 资源` section in README.md, and creates a matching `AI Resources` section in README_en.md.

Bernstein is an open-source (Apache 2.0) multi-agent orchestrator for CLI coding agents — runs Claude Code, Codex CLI, Gemini CLI, OpenHands, Cursor, Aider, and 31 others in parallel git worktrees. Deterministic Python scheduler (zero LLM tokens for coordination), file-based state, MCP server, quality gates, cost tracking. Self-hosted, no SaaS dependency.

Bernstein 是一个开源（Apache 2.0）的多 Agent 编排器，与 AgentsMesh 类似，但使用确定性 Python 调度器（编排零 LLM token），支持 37 个 CLI 编程 Agent。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Bernstein to the AI 资源 list in README.md and created a matching AI Resources section in README_en.md with the same entry and link. This documents an Apache 2.0, self-hosted multi-agent orchestrator for CLI coding agents.

<sup>Written for commit bcf048a8ff96c5f93f9f31574d3be1ad689b42e0. Summary will update on new commits. <a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

