### PR TITLE
Add Cyber Collector — free Telegram video downloader bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@
 -   [Upscayl Upscayl](https://github.com/upscayl/upscayl) - 免费开源 AI 图像放大器
 -   [video 转 gif](https://ezgif.com/video-to-gif)
 -   [MediaGo](https://github.com/caorushizi/mediago) - m3u8 视频在线提取工具
+-   [Cyber Collector](https://t.me/cybercollectorbot) — Free Telegram bot for downloading TikTok (no watermark), Instagram Reels/Stories, YouTube+Shorts, X/Twitter, Facebook videos. No signup, no ads. [Website](https://cybercollector.hitkey.io)
 
 ### 屏幕录制
 


### PR DESCRIPTION
Adding [Cyber Collector](https://t.me/cybercollectorbot) — a free Telegram bot for downloading videos from TikTok (no watermark), Instagram Reels & Stories, YouTube + Shorts, X/Twitter, and Facebook. No signup required, no ads. Website: https://cybercollector.hitkey.io

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cyber Collector to the README video tools list with bot and website links. It’s a free Telegram downloader for TikTok (no watermark), Instagram Reels/Stories, YouTube + Shorts, X/Twitter, and Facebook; no signup, no ads.

<sup>Written for commit d53e8a1432617e4e0e387e4d490f3430117132b9. Summary will update on new commits. <a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/34?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

