### PR TITLE
Add Remove Audio under 图片视频处理工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@
 -   [Upscayl Upscayl](https://github.com/upscayl/upscayl) - 免费开源 AI 图像放大器
 -   [video 转 gif](https://ezgif.com/video-to-gif)
 -   [MediaGo](https://github.com/caorushizi/mediago) - m3u8 视频在线提取工具
+-   [this free browser-based audio remover](https://remove-audio.com) - Free in-browser tool to strip audio from MP4/MOV/WEBM. Local FFmpeg.wasm, no uploads.
 
 ### 屏幕录制
 


### PR DESCRIPTION
Adds Remove Audio to the 图片视频处理工具 section.

Remove Audio is a free, fully client-side tool that strips the audio track from any video using WebAssembly and FFmpeg.wasm. Files never leave the browser, there is no signup, no watermark, and it supports MP4, MOV, MKV, AVI, WEBM with batches up to 20 clips. It fits this list because it is genuinely independent (built and maintained by one developer) and aimed at the same independent-tool audience this list serves.