### PR TITLE
Add TinyTools to Other Tools / 其他工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@
 
 ### 其他工具
 
+-   [TinyTools](https://tinytools-smoky.vercel.app/) - (免费/开源) 浏览器内运行的免登录单一用途网页工具集合。包含域名生成器、OG 图生成器、AI 本地图像背景去除、Favicon 生成器、配色生成器、SEO meta 标签生成器、AI 成本计算器、AI 内容披露生成器（符合欧盟 AI 法案）、AI robots.txt 生成器。
 -   [黑苹果软件园](https://mackext.com/)
 -   [截图工具](https://www.snipaste.com/)
 -   [截图工具](https://pixpinapp.com/) - 解决了 Snipaste 长截图，gif 图问题

--- a/README_en.md
+++ b/README_en.md
@@ -409,6 +409,7 @@ Collect the latest and most practical free tools and resources in the field of i
 
 ### Other Tools
 
+-   [TinyTools](https://tinytools-smoky.vercel.app/) - (Free/Open source) Collection of single-purpose web utilities, all browser-based and no signup required. Includes domain name generator, OG image generator, AI background remover (runs locally), favicon generator, color palette generator, SEO meta tag generator, AI cost calculator, AI content disclosure generator (EU AI Act compliant), and AI robots.txt generator.
 -   [Black Apple Software Park](https://mackext.com/)
 -   [Screenshot Tool](https://www.snipaste.com/)
 -   [Screenshot Tool](https://pixpinapp.com/) - Solves Snipaste's long screenshot and GIF issues.


### PR DESCRIPTION
Adds [TinyTools](https://tinytools-smoky.vercel.app/) to the `其他工具` section in README.md and the `Other Tools` section in README_en.md.

TinyTools is a collection of free single-purpose web utilities — all browser-based with no signup. Includes:
- Domain name generator
- OG image generator
- AI background remover (runs locally in browser)
- Favicon generator
- Color palette generator
- SEO meta tag generator
- AI cost calculator
- AI content disclosure generator (EU AI Act compliant)
- AI robots.txt generator

Open source. Useful for indie hackers and developers shipping side projects.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add TinyTools to the Other Tools / 其他工具 sections in README.md and README_en.md. It links to a free, open-source set of browser-based utilities: domain and OG image generators, local background remover, favicon and color palette tools, SEO meta tag generator, plus AI cost/disclosure/robots.txt helpers.

<sup>Written for commit 708beb073caa9b0ab6a8e4afa5fe1aae59d58f3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

