### PR TITLE
Add Gitchat — developer chat built on GitHub identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 # Awesome-independent-tools
 
+    -   [Gitchat](https://gitchat.sh) - Chat with developers you already follow on GitHub, right inside VS Code, Cursor, or Windsurf. GitHub identity is your login — no new account needed. DMs, group chats, and repo channels. VS Code extension at https://github.com/GitchatSH/gitchat_extension. Free for individuals.
 收录独立开发、AI 出海领域最新、最实用的免费工具与资源
 
 ### 最新工具前往官网：[https://www.indietools.work](https://www.indietools.work)


### PR DESCRIPTION
Hi — long-time reader of this list, it's helped me find a lot of tools I wouldn't have discovered otherwise.

I built something called **Gitchat** and wanted to suggest adding it if it's a good fit.

The idea came from a simple frustration: every time I wanted to reach out to someone I collaborated with on GitHub, I had to track them down on LinkedIn or Twitter. Gitchat fixes that — it uses your GitHub identity as your login, so the people you already follow are automatically in your contact list. You can DM them, start group chats, or join channels tied to specific repos. It also runs as an extension inside VS Code, Cursor, and Windsurf so there's no context switching.

The VS Code extension is open source: https://github.com/GitchatSH/gitchat_extension

I've added it to the **Awesome-independent-tools** section. Happy to adjust the description or move it elsewhere if there's a better spot — and of course, totally fine to decline if it doesn't meet the bar for this list.

Thanks for maintaining yaolifeng0629/Awesome-independent-tools, it's a genuinely useful resource.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Gitchat to the Awesome-independent-tools list with links to the site and open-source VS Code extension. Gitchat uses your GitHub login for chat with people you already follow, supports DMs, group chats, and repo channels, and works inside VS Code, Cursor, and Windsurf; free for individuals.

<sup>Written for commit dbc826b4595b99b6f84d136125ded85bb1ffa9c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

