### PR TITLE
Add AMZ Seller Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@
 - [制作一个基于 API 的工具来拍摄网站快照](https://screenshotone.com/)
 - [Cursor V0 开发步骤](https://x.com/aiwarts/status/1839986188255670602)
 - [Cursor 规则使用指南](https://cursor.directory/)
+- [AMZ Seller Tools](https://www.amzsellerstools.com/en) - 面向亚马逊卖家的免费在线工具集，包含 FBA 费用、利润、仓储、移除和目标成本计算器，无需注册。
 
 <a name="contribute"></a>
 

--- a/README_en.md
+++ b/README_en.md
@@ -427,6 +427,7 @@ Collect the latest and most practical free tools and resources in the field of i
 - [Create an API-based tool to take website snapshots](https://screenshotone.com/)
 - [Cursor V0 Development Steps](https://x.com/aiwarts/status/1839986188255670602)
 - [Cursor Rules Usage Guide](https://cursor.directory/)
+- [AMZ Seller Tools](https://www.amzsellerstools.com/en) - Free browser-based FBA fee, profit, storage, removal, target-cost, and seller utility tools; no signup required.
 
 <a name="contribute"></a>
 


### PR DESCRIPTION
Adds AMZ Seller Tools to the Other Tools section in both the Chinese and English README files. It is a free browser-based toolkit for Amazon sellers, and its core calculators require no signup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add AMZ Seller Tools to the “Other Tools” section in both `README.md` and `README_en.md` to surface a free, browser-based toolkit for Amazon sellers (FBA fees, profit, storage, removal, target-cost) with no signup required.

<sup>Written for commit 88e95372a4eb2e27fb0b95e7fef56cc964ae6460. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

