### PR TITLE
Add HagiCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@
 
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
+- [HagiCode](https://hagicode.com/) - (免费) 本地优先的 AI 编程工作区，支持提案驱动开发、并行多 Agent 执行、多仓库协作，以及提交与知识工作流整合。
 
 ### 其他工具
 


### PR DESCRIPTION
在 `AI 资源` 小节补充 HagiCode。

HagiCode 是本地优先的 AI 编程工作区，支持提案驱动开发、并行多 Agent 执行、多仓库协作，以及提交与知识工作流整合。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added HagiCode to the README tools list. It’s a local-first coding workspace with proposal-driven development, parallel multi-agent execution, multi-repo collaboration, and commit/knowledge workflow integration.

<sup>Written for commit beb3a7af66b25108e8d8e83a8f949a1a2c124123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

