### PR TITLE
feat: 添加 Cate 到 AI 资源分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@
 
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
+- [Cate](https://github.com/0-AI-UG/cate) - (免费开源, MIT) 基于无限缩放画布的桌面 IDE。编辑器、终端、浏览器和 Claude Code 等 AI Agent 面板自由摆放在可缩放的空间里，代替传统的窗口和标签页。面板可悬浮、停靠成标签组，或拆分为独立窗口，布局按项目自动保存。Electron + React + TypeScript 构建，支持 macOS / Windows / Linux。
 
 ### 其他工具
 

--- a/README_en.md
+++ b/README_en.md
@@ -406,6 +406,7 @@ Collect the latest and most practical free tools and resources in the field of i
 ### AI Resources
 
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0, open-source/self-hosted) Multi-agent orchestrator that runs Claude Code, Codex CLI, Gemini CLI, OpenHands, Cursor, Aider, and 31 other CLI coding agents in parallel git worktrees. Deterministic Python scheduler, file-based state, MCP server, quality gates, cost tracking.
+- [Cate](https://github.com/0-AI-UG/cate) - (Free, open source, MIT) A desktop IDE on an infinite zoomable canvas. You arrange editors, terminals, browsers, and Claude Code agent panels in spatial workspace instead of tabs. Panels can float, dock, or detach into separate windows. Layout persists per project. Built with Electron + React + TypeScript, runs on macOS / Windows / Linux.
 
 ### Other Tools
 


### PR DESCRIPTION
添加 Cate，一款开源（MIT）的无限画布桌面 IDE，内置 Claude Code Agent 面板，适合独立开发者免费使用。GitHub 约 1300 stars，持续更新中。官网：https://cate.cero-ai.com


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Cate to the AI Resources section in `README.md` and `README_en.md`. Cate is a free, MIT-licensed desktop IDE on an infinite zoomable canvas with Claude Code agent panels, providing a cross-platform option for developers.

<sup>Written for commit e5e93c8486e73bc8ecb342792712f8633b8f9c20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

