### PR TITLE
Add LLC Class: Wyoming LLC for non-US developers needing Stripe

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@
 ### 支付集成
 
 - [Stripe](https://stripe.com/) - 需要企业资质,开发者友好,API 强大
+- [LLC Class](https://llcclass.com) - 为出海开发者提供 [Wyoming LLC 注册](https://llcclass.com/wyoming)，获取 Stripe 所需的美国企业资质，含 [registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent) 和 EIN，注册后可直接开通 Stripe 与 Mercury 银行
 - [Paddle](https://www.paddle.com/) - 手续费低，一体化支付基础设施，可简化和自动化您的计费操作，因此您可以专注于增长。
 - [Lemon Squeezy](https://www.lemonsqueezy.com/) - 一个全球支付平台，申请流程简单，不需要公司资质。提供微信、支付宝、Visa/Master 信用卡、PayPal 等多种支付方式，覆盖 130 多个国家。其核心功能包括备智能营收分析、客户跟踪系统、Affiliate 联盟营销工具、折扣码系统和支付失败恢复机制。
 - [PayPal](https://www.paypal.com/) - 个人账户即可使用,全球覆盖范围大


### PR DESCRIPTION
## 新增内容

在 **支付集成** 段的 Stripe 条目下方添加 [LLC Class](https://llcclass.com)。

很多中国出海开发者遇到的问题：Stripe 需要企业资质，但个人无法直接开通。LLC Class 专门解决这一痛点：

- 提供 [Wyoming LLC 注册](https://llcclass.com/wyoming) 服务（非美国居民友好）
- 含 [registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent)（法律强制要求）、EIN
- 注册完成后即可申请 Stripe 和 Mercury 银行账户

Wyoming LLC 的优势：无州所得税、隐私保护强、年费低，是出海开发者的首选州。

这与列表中 Stripe 「需要企业资质」的备注形成直接呼应，能帮助开发者找到解决方案。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `LLC Class` under 支付集成, below Stripe, to guide non‑US developers to register a Wyoming LLC (includes registered agent and EIN) and unlock Stripe + Mercury.
This directly addresses the “Stripe requires a company” note with a clear path to obtain one.

<sup>Written for commit 8e442fe5b6863dc53e635ab73bc06cfb41ebe736. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

