### PR TITLE
Add Xianyu Netdisk Delivery Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@
 - [QuickType](https://quicktype.io/) - 一键可以将一个 JSON 结构生成对应的类型
 - [Linear](https://linear.app/) - Linear 是一个项目管理和任务跟踪软件
 - [Remotion](https://www.remotion.dev/) - 一个通过编码创建视频的工具
+- [闲鱼虚拟资料网盘发货检查器](https://ronnie2025.github.io/xianyu-netdisk-delivery-checker/) - 免费浏览器端发货前检查工具，帮助虚拟资料卖家在发送网盘链接前生成买家说明、售后边界和订单记录 CSV。
 - [制作一个基于 API 的工具来拍摄网站快照](https://screenshotone.com/)
 - [Cursor V0 开发步骤](https://x.com/aiwarts/status/1839986188255670602)
 - [Cursor 规则使用指南](https://cursor.directory/)

--- a/README_en.md
+++ b/README_en.md
@@ -424,6 +424,7 @@ Collect the latest and most practical free tools and resources in the field of i
 - [QuickType](https://quicktype.io/) - Instantly generates corresponding types from a JSON structure.
 - [Linear](https://linear.app/) - Linear is a project management and task tracking software.
 - [Remotion](https://www.remotion.dev/) - A tool to create videos through coding.
+- [Xianyu Netdisk Delivery Checker](https://ronnie2025.github.io/xianyu-netdisk-delivery-checker/) - Free browser-side pre-delivery checker that helps digital-product sellers generate buyer instructions, after-sales boundaries, and order-record CSV before sending netdisk links.
 - [Create an API-based tool to take website snapshots](https://screenshotone.com/)
 - [Cursor V0 Development Steps](https://x.com/aiwarts/status/1839986188255670602)
 - [Cursor Rules Usage Guide](https://cursor.directory/)


### PR DESCRIPTION
Add Xianyu Netdisk Delivery Checker to the Other Tools section in both README.md and README_en.md.\n\nWhy it fits:\n- It is a free browser-side tool for digital-product sellers.\n- It helps sellers generate buyer instructions, after-sales boundaries, and order-record CSV before sending netdisk links.\n- The tool is useful for solo builders or small sellers who sell templates, documents, spreadsheets, prompt packs, or other digital materials.\n\nNo affiliate link is included in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Xianyu Netdisk Delivery Checker to the Other Tools section in `README.md` and `README_en.md`. This adds a free browser-side pre-delivery checker that helps digital-product sellers generate buyer instructions, after-sales boundaries, and an order-record CSV.

<sup>Written for commit 53a7f1a3975ad609df8eb9d327bee85fe646b27c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

