### PR TITLE
feat: add NotFair — open-source Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@
 
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
+- [NotFair](https://github.com/nowork-studio/NotFair) - (MIT 开源) Claude Code 营销技能插件，约 2.9k stars。涵盖 [SEO](https://github.com/nowork-studio/NotFair/tree/main/seo)、[Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads)、[Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads) 三大方向，通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics (GA4) MCP 连接真实账户数据，实现关键词分析、浪费支出检测、创意疲劳诊断等自动化工作流。
 
 ### 其他工具
 


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great resource for indie developers.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** (MIT, ~2.9k stars) to the **AI 资源** section. It's an open-source set of Claude Code agent skills covering three marketing areas:

- **SEO** — site analysis, keyword research, meta tags, schema markup, GEO optimization, content writing
- **Google Ads** — audits, wasted-spend detection, search-term cleanup, keyword and bid management
- **Meta Ads** — ROAS analysis, creative fatigue detection, audience overlap diagnostics

It connects to live account data through the **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP**, so the skills work against real data rather than static files.

I placed it in the AI 资源 section alongside the other Claude Code / agent tools there. Happy to move it, reword the description, or trim anything that doesn't fit the list's style.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add NotFair (MIT) to the AI 资源 section. It provides Claude Code marketing skills for SEO, Google Ads, and Meta Ads, with live-data integrations via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and GA4 MCP.

<sup>Written for commit eb966bb130825cba71d80510b198bdb9cae2f1c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

