### PR TITLE
Add sunwatch -- crypto-paid uptime monitor

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -270,6 +270,7 @@ Collect the latest and most practical free tools and resources in the field of i
 - [Is It Down?](https://zhale.me/) - An online network testing tool for ops and webmasters, with over 1,000 global nodes, simulating user access to domains/IPs, offering free website speed tests, network speed detection, multi-region online ping tests, DNS queries, route tracking, and IPv6 website tests.
 - [Deploy UptimeRobot API Status Panel with Cloudflare Pages: `Tutorial`](https://blog.aizrf.com/p/62)
 - [Deploy UptimeRobot API Status Panel with Cloudflare Pages: `Project`](https://github.com/shaoyouvip/uptime)
+- [sunwatch](https://sunwatch.sunfamily.xyz) ([repo](https://github.com/ryan-knowone/sunwatch)) - (Freemium) Crypto-paid uptime monitor for side projects. 3 free monitors with 1-minute checks and webhook alerts; extras at $1/monitor/month paid with USDC on Base. No account, no KYC.
 - [Improve Website Access Speed with CNAME Domains](https://www.igeekbb.com/2024/09/26/cloudflare-saas/)
 
 ### Domain Registration


### PR DESCRIPTION
Add [sunwatch](https://sunwatch.sunfamily.xyz) to the Site Management section.\n\nsunwatch is a crypto-paid uptime monitor for side projects:\n- 3 free monitors with 1-minute checks and webhook alerts\n- Extra monitors at $1/monitor/month, paid with USDC on Base\n- No account, no KYC, no subscription\n\nOpen-source repo: https://github.com/ryan-knowone/sunwatch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added sunwatch to the Site Management tools list in README_en.md. It’s a crypto-paid uptime monitor with 3 free monitors (1‑minute checks, webhook alerts) and extras at $1/monitor/month via USDC on Base, with no account or KYC.

<sup>Written for commit 8e11c6d47afc5c50d721ce3ae411a36ea9892835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

