### PR TITLE
Add agent-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@
 
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
+- [agent-qa](https://github.com/vostride/agent-qa) - (FSL-1.1-ALv2/可自部署) 面向 Web 和移动应用的自改进 QA Agent，支持自然语言测试、运行记忆、适应 UI 变化，并在发布前捕获回归。
 
 ### 其他工具
 

--- a/README_en.md
+++ b/README_en.md
@@ -406,6 +406,7 @@ Collect the latest and most practical free tools and resources in the field of i
 ### AI Resources
 
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0, open-source/self-hosted) Multi-agent orchestrator that runs Claude Code, Codex CLI, Gemini CLI, OpenHands, Cursor, Aider, and 31 other CLI coding agents in parallel git worktrees. Deterministic Python scheduler, file-based state, MCP server, quality gates, cost tracking.
+- [agent-qa](https://github.com/vostride/agent-qa) - (FSL-1.1-ALv2/self-hosted) Self-improving QA agent for web and mobile apps. Write tests in natural language, retain run memory, adapt to UI changes, and catch regressions before shipping.
 
 ### Other Tools
 


### PR DESCRIPTION
## Summary
- Add agent-qa to the AI Resources section in both Chinese and English READMEs
- Describe its natural-language QA tests, run memory, UI-change adaptation, and regression detection

## Check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `agent-qa` to the AI Resources section in both `README.md` and `README_en.md`. Describes it as a self-improving QA agent for web and mobile with natural-language tests, run memory, UI-change adaptation, and pre-release regression detection.

<sup>Written for commit 2d37cc05a6b07d520386eedca4e219a956c38848. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Disclosure: I am affiliated with Agent QA and Vostride.