### PR TITLE
Add Kostra to Web Framework/Template section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [discourse](https://www.discourse.org/) - 社区讨论的平台
 - [umami](https://github.com/umami-software/umami) - 简单、快速、注重隐私的 Google Analytics 替代方案
 - [Free for Developers](https://free-for.dev/#/) - 一个专门为开发者收集整理免费在线工具资源的网站
+- [Kostra](https://kostra.io) - (付费) 基于 Next.js 的 SaaS 模板，集成了登录、支付（Stripe）、基于积分的用量计费和管理后台
 
 ### Chrome 插件开发
 

--- a/README_en.md
+++ b/README_en.md
@@ -81,6 +81,7 @@ Collect the latest and most practical free tools and resources in the field of i
 - [umami](https://github.com/umami-software/umami) - A simple, fast, privacy-focused alternative to Google Analytics.
 - [Free for Developers](https://free-for.dev/#/) - A website dedicated to collecting and organizing free online tools and resources for developers.
 - [BeginThings](https://beginthings.com/) - 96+ free browser-based tools for developers & freelancers — JSON formatter, regex tester, base64 encoder, image compressor, QR code generator, invoice builder & more. No signup required.
+- [Kostra](https://kostra.io) - (Paid) Next.js SaaS boilerplate with login, Stripe billing, credit-based usage billing, and an admin dashboard.
 
 ### Chrome Extension Development
 


### PR DESCRIPTION
Adds Kostra, a Next.js SaaS boilerplate (login, Stripe billing, credit-based usage billing, admin dashboard), to the Web Framework/Template section in both README.md and README_en.md, following the existing format used for similar entries (Shipfast, SupaStarter, Opensaas).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Kostra, a paid Next.js SaaS boilerplate (login, Stripe billing, credit-based usage, admin dashboard), to the Web Framework/Template section in README.md and README_en.md to help users find production-ready templates.

<sup>Written for commit 47170474fed097804a14f3c5a6d530cdbbe9beaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

