### PR TITLE
PinZheng(docs): add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@
 
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
+- [codex-profiles](https://github.com/Ducksss/codex-profiles) - (MIT 开源) 为 Codex CLI 选择独立的命名 CODEX_HOME，并在 macOS 上为命名 ChatGPT Desktop 窗口选择独立本地状态，不读取或复制令牌。
 
 ### 其他工具
 

--- a/README_en.md
+++ b/README_en.md
@@ -406,6 +406,7 @@ Collect the latest and most practical free tools and resources in the field of i
 ### AI Resources
 
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0, open-source/self-hosted) Multi-agent orchestrator that runs Claude Code, Codex CLI, Gemini CLI, OpenHands, Cursor, Aider, and 31 other CLI coding agents in parallel git worktrees. Deterministic Python scheduler, file-based state, MCP server, quality gates, cost tracking.
+- [codex-profiles](https://github.com/Ducksss/codex-profiles) - (MIT, open source) Uses named CODEX_HOME directories for Codex CLI and separate local state for named ChatGPT Desktop windows on macOS, without copying tokens.
 
 ### Other Tools
 


### PR DESCRIPTION
## Summary

- Add codex-profiles to the English and Chinese AI Resources sections.
- Describe named CODEX_HOME and macOS ChatGPT Desktop local state without unsupported account claims.

Related issue: https://github.com/yaolifeng0629/Awesome-independent-tools/issues/81

I maintain [codex-profiles](https://github.com/Ducksss/codex-profiles) and am disclosing that affiliation here.

## Validation

- `git diff --check`
- `Confirmed one matching entry in each language README.`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `codex-profiles` to the AI Resources list in both English and Chinese READMEs. Explains using named CODEX_HOME for Codex CLI and separate local state for named ChatGPT Desktop windows on macOS, without copying tokens or unsupported account claims.

<sup>Written for commit a8a81f2e5f21a19de827f0068e3305e51453605e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

