### PR TITLE
新增:AgentCeres

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@
 
 ### AI 资源
 
+- [AgentCeres](https://agentceres.com) - 面向出海独立开发者的 AI 增长团队，营销 Agent 分工做竞品调研、SEO 文章与社媒内容草稿，发布前人工审批，14 天免费试用，无需绑卡。
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
 

--- a/README_en.md
+++ b/README_en.md
@@ -405,6 +405,7 @@ Collect the latest and most practical free tools and resources in the field of i
 
 ### AI Resources
 
+- [AgentCeres](https://agentceres.com) - An AI growth team for indie developers going global. Marketing agents divide up competitor research, SEO article drafts, and social content drafts, with every publish requiring human approval. 14-day free trial, no credit card required.
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0, open-source/self-hosted) Multi-agent orchestrator that runs Claude Code, Codex CLI, Gemini CLI, OpenHands, Cursor, Aider, and 31 other CLI coding agents in parallel git worktrees. Deterministic Python scheduler, file-based state, MCP server, quality gates, cost tracking.
 
 ### Other Tools


### PR DESCRIPTION
AgentCeres（https://agentceres.com）是面向出海独立开发者和小团队的 AI 增长团队产品，营销 Agent 分工负责竞品调研、SEO 文章草稿与社媒内容草稿，所有对外发布都需要人工审批。支持接入 GA4/Search Console/社媒/广告账号，提供 14 天免费试用，无需绑卡。

已添加到「AI 资源」分类（中英文 README 均已同步更新）。


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `AgentCeres` to the Resources section in `README.md` and `README_en.md`, with a brief description and trial details for indie developers targeting global markets. This surfaces a growth tool that handles competitor research, SEO drafts, and social content drafts with human approval before publishing.

<sup>Written for commit e83e4a4232da2022d948c7f2181e6ccc959fe5bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
