### PR TITLE
Add ExcaliRec to screen recording tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@
 - [QuickRecorder](https://github.com/lihaoyun6/QuickRecorder) - 多功能、轻量化、高性能的开源 macOS 屏幕录制工具
 - [screenity](https://github.com/alyssaxuu/screenity) - 一款开源的屏幕录制和标注工具，提供隐私保护且无任何使用限制
 - [focusee](https://gemoo.com/focusee/) - 一个一站式平台，简化了视频的创建、编辑和分享流程，让每个人都能在几分钟内制作视频并传播自己的创意
+- [ExcaliRec](https://excalirec.com/) - 免费的浏览器白板录屏工具，面向 Excalidraw 风格讲解视频，支持自动聚焦缩放和本地录制，无需安装或注册
 
 ### 短链或长链
 

--- a/README_en.md
+++ b/README_en.md
@@ -336,6 +336,7 @@ Collect the latest and most practical free tools and resources in the field of i
 - [QuickRecorder](https://github.com/lihaoyun6/QuickRecorder) - A multifunctional, lightweight, high-performance open-source macOS screen recording tool.
 - [screenity](https://github.com/alyssaxuu/screenity) - An open-source screen recording and annotation tool, privacy-protected with no usage restrictions.
 - [focusee](https://gemoo.com/focusee/) - A one-stop platform simplifying video creation, editing, and sharing, allowing everyone to create and share their ideas in minutes.
+- [ExcaliRec](https://excalirec.com/) - A free browser-based whiteboard recorder for Excalidraw-style explainers, with auto-focus zoom and local recording; no install or sign-up required.
 
 ### URL Shortener
 


### PR DESCRIPTION
Adds ExcaliRec to the Screen Recording sections in both Chinese and English.\n\nExcaliRec is a free browser-based whiteboard recorder for Excalidraw-style explainers, with auto-focus zoom and local recording. It requires no installation or sign-up.\n\nProduct: https://excalirec.com/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ExcaliRec to the Screen Recording tools list in both README and README_en to broaden options for whiteboard-style recordings. It’s a free browser-based recorder for Excalidraw-style explainers with auto-focus zoom and local recording; no install or sign-up required.

<sup>Written for commit a8474eda356197a6b01655807c2e14827fad3e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

