### PR TITLE
添加 Tura AI 编程 Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@
 
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
+- [Tura](https://github.com/Tura-AI/tura) - (AGPL-3.0 开源/本地优先) Rust 编写的 AI 编程 Agent，提供 CLI、TUI、桌面与 Web 界面，支持 OpenAI-compatible API 和本地模型配置，并公开可复现 benchmark 数据。
 
 ### 其他工具
 


### PR DESCRIPTION
## 说明

将 [Tura](https://github.com/Tura-AI/tura) 添加到 **AI 资源** 分类。

Tura 是 AGPL-3.0 开源、本地优先的 AI 编程 Agent，使用 Rust 编写，提供 CLI、TUI、桌面与 Web 界面，并支持 OpenAI-compatible API 和本地模型配置。项目还公开了可复现 benchmark 数据。

官网：https://turaai.net/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
在 README 的 AI 编程 Agent 列表中新增 `Tura`，方便用户发现与对比同类工具。
补充其核心信息：AGPL-3.0、Rust 实现，提供 CLI/TUI/桌面/Web，支持 OpenAI-compatible API 与本地模型，并公开可复现 benchmark。

<sup>Written for commit bf14c3b24750bac56c37927f3750dd33022f7342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

