### PR TITLE
更新 Clerk 条目：免费额度已调整为 50,000 MRU

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@
 - [Lucia](https://lucia-auth.com/)
 - [Auth.js](https://authjs.dev/) - 支持 Nuxt, SolidStart, Astro 等
 - [Next Auth.js](https://next-auth.js.org/) - 支持 Next.js
-- [Clerk](https://clerk.com/) - 免费用户有 5000 MAU
+- [Clerk](https://clerk.com) - 用户管理平台：内置登录/注册组件、组织管理与计费。免费额度 50,000 MRU。
 - [NextAuth](https://github.com/nextauthjs/next-auth) - 用户系统, 网络身份验证
 
 ### 支付集成


### PR DESCRIPTION
Clerk 的免费额度已经更新，当前条目中的「免费用户有 5000 MAU」已过时。

本次修改：
- 免费额度更新为 50,000 MRU（monthly retained users），参见 [clerk.com/pricing](https://clerk.com/pricing)
- 补充了简短的产品描述（登录/注册组件、组织管理与计费）

说明：我在 Clerk 工作（I work at Clerk）。如需调整措辞，欢迎直接修改。感谢维护这份清单！

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
将 README 中的 `Clerk` 条目更新为当前定价与定位：把免费额度从“5000 MAU”更正为“50,000 MRU”，并补充简短产品说明（登录/注册组件、组织管理与计费）。
确保清单中的认证服务信息准确、便于对比。

<sup>Written for commit 32f48cfb715f4486690e2fb68fe071b83e29c8c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

