### PR TITLE
添加 Markstream 到前端开发工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 
 - [Next.js](https://nextjs.org/) - 基于 React
 - [Nuxt](https://nuxt.com/) - 基于 Vue
+- [Markstream](https://github.com/Simon-He95/markstream-vue) - 面向 AI 对话界面的开源流式 Markdown 渲染器，支持 Vue、React、Svelte、Angular、Nuxt、Next.js 和 Vue 2，并集成 Mermaid、KaTeX、Shiki 与安全 HTML 策略
 - [Remix](https://remix.run/) - 基于 React 的全栈框架
 - [Webpack Config Tool](https://createapp.dev/webpack/no-library) - 一键帮你生成 webpack.config.js
 - [AutoX.js](http://doc.autoxjs.com/) - 不需要 Root 权限 的 JavaScript 自动化软件


### PR DESCRIPTION
感谢维护这份独立开发者工具清单。

本次仅新增一个资源：将 Markstream 加入「前端开发」分类。Markstream 是面向 AI 对话界面的开源流式 Markdown 渲染器，提供 Vue、React、Svelte、Angular、Nuxt、Next.js 和 Vue 2 适配包，并支持 Mermaid、KaTeX、Shiki、Monaco 与安全 HTML 策略。

- GitHub：https://github.com/Simon-He95/markstream-vue
- 文档：https://markstream.simonhe.me/
- 在线演示：https://markstream-vue.simonhe.me/

提交前已检查 README、Issue 和 PR，没有发现 Markstream 的现有条目或重复投稿；新增内容也沿用了仓库要求的 `[工具名称](链接) - 简短描述` 格式。如需调整措辞或分类，我会及时配合。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
在前端开发工具列表中新增 Markstream 条目，完善该分类的 Markdown 渲染方案覆盖。
Markstream 是面向对话界面的开源流式 Markdown 渲染器，支持 Vue、React、Svelte、Angular、Nuxt、Next.js、Vue 2，并集成 Mermaid、KaTeX、Shiki 与安全 HTML 策略。

<sup>Written for commit d530b5ae8146e5c422a7a99f1ab25dec3ec39d3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

