### PR TITLE
Add Darkmoon (autonomous pentest, AD + Kubernetes + web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@
 
 ### 部署与托管
 
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Autonomous AI pentesting platform (GPL-3.0) covering web, AD and Kubernetes, where the LLM never sees real IPs or credentials (local privacy gateway).
 - [FlyPloy](https://flyploy.com/en) - (免费/付费) 简单强大的现代化应用部署平台，支持 Docker 和 Kubernetes，助力开发者实现全球一键快速部署。
 - [Vercel](https://vercel.com/dashboard) - 首选，国内大部分访问不了
 - [阿里云](https://www.aliyun.com/minisite/goods) - 国内云


### PR DESCRIPTION
Hi, thanks for maintaining this list. Adding Darkmoon, a GPL-3.0 autonomous penetration testing platform covering Active Directory and Kubernetes alongside web and APIs. Repo: https://github.com/ASCIT31/Dark-Moon

Full disclosure: our project. Happy to adjust or close if not a fit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Darkmoon to the README under “部署与托管”. Darkmoon is a GPL-3.0 autonomous pentesting platform covering web, Active Directory, and Kubernetes, with a local privacy gateway to avoid exposing real IPs or credentials.

<sup>Written for commit b51bfecb0a42f56d3efb80f7dece2f4cc2973bf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

