### PR TITLE
Add Nutilz File Size Converter to image/video processing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@
 
 - [Tinypng](https://tinypng.com/) - 图片压缩工具
 - [tiny-img](https://tiny-img.com/webp/) - PNG、JPG 格式压缩并转换为 WEBP
+- [Nutilz File Size Converter](https://nutilz.com/file-size-converter) - Free browser-based file size unit converter (bytes/KB/MB/GB/TB), no upload required
 - [在线 AI 抠图工具](https://removebg.one/)
 - [Upscayl Upscayl](https://github.com/upscayl/upscayl) - 免费开源 AI 图像放大器
 - [video 转 gif](https://ezgif.com/video-to-gif)


### PR DESCRIPTION
Adds a free, browser-based file size unit converter (bytes/KB/MB/GB/TB) alongside the existing compression tools (Tinypng, tiny-img) in this section. No signup, no upload required — runs client-side. https://nutilz.com/file-size-converter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `Nutilz File Size Converter` to the image/video processing tools list to help users convert file size units in the browser with no uploads.
Supports bytes/KB/MB/GB/TB.

<sup>Written for commit b86e9fcdad454e94fb87919142a8ab60836d0589. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

