### PR TITLE
添加 Payload Components 到样式与 UI 框架

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@
 - [通过图形化编辑器轻松创建和自定义各种网页组件](https://tailwind-generator.com/)
 - [一个专门处理数字动画的 React 组件](https://github.com/barvian/number-flow)
 
+- [Payload Components](https://www.payload-components.xyz) - 面向 Payload v3 与 Next.js 15/16 的 MIT 开源区块注册表；67 个类型安全区块以源码形式安装，并自动完成 Pages、渲染器、类型和后台 import map 接线。
+
 ### 原型设计
 
 - [墨刀](https://modao.cc/) - 国内产品原型设计工具


### PR DESCRIPTION
Awesome-independent-tools 在「样式与 UI 框架」中集中收录 shadcn/ui 以及可复用的前端组件资源。

新增的 [Payload Components](https://www.payload-components.xyz) 为 Payload v3 + Next.js 15/16 开发者提供 67 个 MIT 类型安全区块。区块以可审查源码进入项目，CLI 同时完成 Pages、RenderBlocks、类型生成和后台 import map 接线，减少独立开发者重复搭建 CMS 页面区块的时间。

本次改动只增加一条中文说明，并保持该目录现有的列表格式。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
在「样式与 UI 框架」中新增 Payload Components 资源，方便 Payload v3 + Next.js 15/16 开发者获取 67 个 MIT 类型安全区块，支持源码安装与 CLI 自动接线（Pages、渲染器、类型、后台 import map）。本次仅更新 README，无其他改动。

<sup>Written for commit d4675c59987fbb16cc4ebe4ef319e6a9a9c212f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

