### PR TITLE
Add Videosays video transcription tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@
 - [MediaGo](https://github.com/caorushizi/mediago) - m3u8 视频在线提取工具
 - [igly.ai](https://igly.ai) - AI 图像编辑平台 背景移除、AI 填充、图片放大、智能修图
 - [this free browser-based audio remover](https://remove-audio.com) - Free in-browser tool to strip audio from MP4/MOV/WEBM. Local FFmpeg.wasm, no uploads.
+- [Videosays](https://videosays.com/zh) - 粘贴 YouTube、TikTok、抖音等公开视频链接，提取文案和时间轴字幕，支持 TXT、SRT、VTT、API、CLI 及 AI Agent Skill
 
 ### 屏幕录制
 

--- a/README_en.md
+++ b/README_en.md
@@ -329,6 +329,7 @@ Collect the latest and most practical free tools and resources in the field of i
 - [Upscayl Upscayl](https://github.com/upscayl/upscayl) - A free and open-source AI image upscaler.
 - [Video to GIF](https://ezgif.com/video-to-gif)
 - [MediaGo](https://github.com/caorushizi/mediago) - An online m3u8 video extraction tool.
+- [Videosays](https://videosays.com/) - Turn public YouTube, TikTok, Instagram, X, Douyin, and other video links into text and timestamped subtitles, with TXT, SRT, VTT, API, CLI, and AI agent skill support.
 
 ### Screen Recording
 


### PR DESCRIPTION
## Summary

- add Videosays to the image and video processing tools section
- include matching Chinese and English descriptions
- link to the localized product pages

Videosays turns supported public video links into transcripts and timestamped subtitles, with TXT, SRT, VTT, API, CLI, and AI agent skill support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Videosays to the Image and Video Processing tools list in `README.md` and `README_en.md`. Includes localized links and a short feature blurb for transcripts and timestamped subtitles (TXT, SRT, VTT) plus API and CLI support.

<sup>Written for commit 662234541aa22f3ea8937674c3042a5e4f64bb2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

