### PR TITLE
Add cv.cm (browser-local PDF / image / clipboard tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@
 - [toSound](https://www.tosound.com/) - 免费音效素材资源下载
 - [美国虚拟地址生成器](https://www.fakexy.com/fake-address-generator-ca)
 - [code share](https://codeshare.io/) - 实时代码共享工具
+- [Cloud Clipboard (cv.cm)](https://cv.cm) - 免费免登录跨设备云剪贴板，支持文本/文件短链分享，并提供 AI 视频与图片生成
 - [Monica](https://chromewebstore.google.com/detail/monica-your-ai-copilot-po/ofpnmcalabcbjgholdjcjblkibolbppb?hl=zh-CN&utm_source=ext_sidebar) - 针对每个网站推荐常用的 AI 工具，一点即用
 - [QuickType](https://quicktype.io/) - 一键可以将一个 JSON 结构生成对应的类型
 - [Linear](https://linear.app/) - Linear 是一个项目管理和任务跟踪软件

--- a/README_en.md
+++ b/README_en.md
@@ -420,6 +420,7 @@ Collect the latest and most practical free tools and resources in the field of i
 - [toSound](https://www.tosound.com/) - Free sound effect resources download.
 - [US Virtual Address Generator](https://www.fakexy.com/fake-address-generator-ca)
 - [code share](https://codeshare.io/) - Real-time code sharing tool.
+- [Cloud Clipboard (cv.cm)](https://cv.cm) - Free no-login cloud clipboard for text/files, plus AI video and image generation
 - [Monica](https://chromewebstore.google.com/detail/monica-your-ai-copilot-po/ofpnmcalabcbjgholdjcjblkibolbppb?hl=zh-CN&utm_source=ext_sidebar) - Recommends commonly used AI tools for each website, one-click usage.
 - [QuickType](https://quicktype.io/) - Instantly generates corresponding types from a JSON structure.
 - [Linear](https://linear.app/) - Linear is a project management and task tracking software.


### PR DESCRIPTION
Updates the listing after cv.cm dropped AI video generation.

Now: in-browser PDF / image / QR tools (files stay on the device) plus a no-login cloud clipboard.