### PR TITLE
添加 ItsPaint 到图片视频处理工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@
 - [MediaGo](https://github.com/caorushizi/mediago) - m3u8 视频在线提取工具
 - [igly.ai](https://igly.ai) - AI 图像编辑平台 背景移除、AI 填充、图片放大、智能修图
 - [this free browser-based audio remover](https://remove-audio.com) - Free in-browser tool to strip audio from MP4/MOV/WEBM. Local FFmpeg.wasm, no uploads.
+- [ItsPaint](https://github.com/joshlin2201/itspaint) - 免费开源的 macOS 原生画图工具，截图标注、裁剪、一键去背景，完全离线无任何网络请求
 
 ### 屏幕录制
 


### PR DESCRIPTION
在 **图片视频处理工具** 分类中添加 [ItsPaint](https://github.com/joshlin2201/itspaint)。

macOS 原生的画图和标注工具，MIT 开源，安装包 2.9 MB，Mac App Store 上免费。可以新建任意尺寸的空白画布、裁剪、把一张图片贴到另一张上面，截图标注支持自动编号步骤标记和局部马赛克，还有一键去背景（不使用任何 AI 模型，纯 flood fill 实现）。

**完全没有网络代码，也没有申请任何网络权限**，所以即使代码想联网，系统内核也会直接拒绝。README 里有三条命令可以自己验证这一点，不需要相信我的说法。

Adding ItsPaint under 图片视频处理工具, following the stated format `[工具名称](链接) - 简短描述`, one tool per PR, no trailing whitespace. It is a native macOS paint and markup app, MIT licensed, 2.9 MB, free on the Mac App Store, with no network code and no network entitlement at all.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
在“图片视频处理工具”分类中新增 `ItsPaint`，一个免费开源的 macOS 原生画图与标注工具。
支持截图标注、裁剪、一键去背景，完全离线，无任何网络请求。

<sup>Written for commit 112b7f928b8dbbf07ca7aa25ecab072333ea1430. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

