### PR TITLE
Add DSH Studio to AI Resources / AI 资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,8 @@
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
 
+-   [DSH Studio](https://github.com/Moresyl/dsh-studio) - (MIT 开源/本地运行) 跨平台 DeepSeek Harness 桌面管理工具，可完成安装、启动、停止、健康检查、日志查看与进程监管；提供 macOS（Apple Silicon/Intel）、Windows 和 Linux 安装包。
+
 ### 其他工具
 
 - [黑苹果软件园](https://mackext.com/)
@@ -493,3 +495,4 @@
 ## 贡献者
 
 <a href="https://github.com/yaolifeng0629/Awesome-independent-tools/graphs/contributors"><img src="https://contrib.nn.ci/api?repo=yaolifeng0629/Awesome-independent-tools" /></a>
+

--- a/README_en.md
+++ b/README_en.md
@@ -407,6 +407,8 @@ Collect the latest and most practical free tools and resources in the field of i
 
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0, open-source/self-hosted) Multi-agent orchestrator that runs Claude Code, Codex CLI, Gemini CLI, OpenHands, Cursor, Aider, and 31 other CLI coding agents in parallel git worktrees. Deterministic Python scheduler, file-based state, MCP server, quality gates, cost tracking.
 
+-   [DSH Studio](https://github.com/Moresyl/dsh-studio) - (MIT open-source/local-first) Cross-platform desktop manager for DeepSeek Harness with installation, start/stop controls, health checks, logs, and process supervision. Ships installers for macOS (Apple Silicon/Intel), Windows, and Linux.
+
 ### Other Tools
 
 - [Black Apple Software Park](https://mackext.com/)
@@ -479,3 +481,4 @@ If you find this project useful, please consider:
 ## Contributors
 
 <a href="https://github.com/yaolifeng0629/Awesome-independent-tools/graphs/contributors"><img src="https://contrib.nn.ci/api?repo=yaolifeng0629/Awesome-independent-tools" /></a>
+


### PR DESCRIPTION
## 变更说明

在中文与英文的 **AI 资源 / AI Resources** 分类中加入 DSH Studio，并保持两个列表同步。

DSH Studio 是 MIT 开源、本地运行的跨平台 DeepSeek Harness 桌面管理工具，支持安装、启动/停止、健康检查、日志和进程监管。v0.1.1 提供 macOS（Apple Silicon/Intel）、Windows 和 Linux 安装包。

## Change summary

Adds DSH Studio to **AI 资源** in `README.md` and **AI Resources** in `README_en.md`.

DSH Studio is an MIT-licensed, local-first desktop manager for DeepSeek Harness. It provides installation, start/stop controls, health checks, logs, and process supervision, with packaged releases for macOS, Windows, and Linux.

## Validation

- updated both language files with equivalent entries
- confirmed no existing DSH Studio entry
- placed the entry after the existing AI-agent orchestration tools
- repository: https://github.com/Moresyl/dsh-studio
- release: https://github.com/Moresyl/dsh-studio/releases/tag/v0.1.1

Disclosure: I maintain DSH Studio.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DSH Studio to the Chinese and English Resources lists to keep them synchronized and highlight a local-first DeepSeek Harness desktop manager. Previously the lists omitted DSH Studio; now both `README.md` and `README_en.md` include it, placed after existing orchestration tools.

- Verify both files contain equivalent wording and the same link.
- Check the placement aligns with the surrounding orchestration tools and introduces no duplicates.

<sup>Written for commit e1207b71ea2ba647e92a003865457dd79775eb34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

