### PR TITLE
Add Codex Quota Overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@
 
 ### 其他工具
 
+- [Codex Quota Overlay](https://github.com/cpys/codex-quota-overlay) - 面向 Windows 和 macOS 的隐私友好 Codex 桌面配额悬浮层，显示配额、重置时间和重置额度。
 - [黑苹果软件园](https://mackext.com/)
 - [截图工具](https://www.snipaste.com/)
 - [截图工具](https://pixpinapp.com/) - 解决了 Snipaste 长截图，gif 图问题

--- a/README_en.md
+++ b/README_en.md
@@ -409,6 +409,7 @@ Collect the latest and most practical free tools and resources in the field of i
 
 ### Other Tools
 
+- [Codex Quota Overlay](https://github.com/cpys/codex-quota-overlay) - Privacy-friendly Windows/macOS desktop overlay for Codex quota, reset time, and reset credits.
 - [Black Apple Software Park](https://mackext.com/)
 - [Screenshot Tool](https://www.snipaste.com/)
 - [Screenshot Tool](https://pixpinapp.com/) - Solves Snipaste's long screenshot and GIF issues.


### PR DESCRIPTION
## What changed

- Add Codex Quota Overlay to the Other Tools section in both the English and Chinese lists.
- The entry links to the public repository and uses a factual one-line description.

## Disclosure

I am the maintainer of Codex Quota Overlay. It is an independent community project and is not affiliated with, endorsed by, or supported by OpenAI. This is a non-sponsored directory contribution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Codex Quota Overlay” to the “Other Tools” section in `README.md` and `README_en.md` to surface a privacy-friendly Windows/macOS overlay that displays Codex quota, reset time, and reset credits. Documentation-only change; no build or runtime impact.

- **Review**
  - Confirm link placement under “Other Tools” and consistent formatting with adjacent entries.
  - Verify neutral, factual one-line descriptions in English and Chinese.
  - No migration or rollout steps.

<sup>Written for commit 23b0e486c1c6038fde24bec5d6b1ee9b2edd7789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

