### PR TITLE
添加 SandBase CLI 到 AI 资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@
 
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
+- [SandBase CLI](https://github.com/sandbaseai/cli) - (Apache 2.0 开源) 本地 MCP 桥接 CLI，将 Claude Code、Cursor、Codex、ChatGPT 等 AI 客户端连接到 2,000+ AI 模型和 API；支持 OAuth 与回滚。安装：`npx -y @sandbaseai/cli@0.1.14 connect --client claude-desktop`。
 
 ### 其他工具
 


### PR DESCRIPTION
将 SandBase CLI 收录到 AI 资源，基于官方仓库和已发布 npm 包信息。

- Apache 2.0 开源本地 MCP 桥接 CLI
- 连接 2,000+ AI 模型和 API
- 使用固定版本安装命令

来源：https://github.com/sandbaseai/cli

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SandBase CLI to the AI resources list in `README.md`. SandBase CLI is an Apache 2.0 open-source local MCP bridge that connects AI clients like Claude Code and Cursor to 2,000+ models and APIs.

- Lists the pinned install command: `npx -y @sandbaseai/cli@0.1.14 connect --client claude-desktop`.
- Sources the entry from the official GitHub repo and published npm package.

<sup>Written for commit 7558ae7c0fedab3cff87ed627bd310b4bb9c2754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

