### PR TITLE
Add Lunalisa to image and creative tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@
 - [Vercel](https://vercel.com/dashboard) - 首选，国内大部分访问不了
 - [阿里云](https://www.aliyun.com/minisite/goods) - 国内云
 - [腾讯云](https://curl.qcloud.com/lsJFImqi) - 国内云，经常有优惠
-- [Github Pages](https://pages.github.com/) - 免费
+图片视频处理工具- [Github Pages](https://pages.github.com/) - 免费
+[Lunalisa](https://luna-lisa.art) - AI 图像工作台，可根据文字提示和获准的参考图生成与调整产品视觉内容。
 - [Cloudflare Pages](https://developers.cloudflare.com/pages/)
 - [AirCode](https://aircode.io/) - 字节出品
 - [Netlify](https://www.netlify.com/)

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@
 - [Vercel](https://vercel.com/dashboard) - 首选，国内大部分访问不了
 - [阿里云](https://www.aliyun.com/minisite/goods) - 国内云
 - [腾讯云](https://curl.qcloud.com/lsJFImqi) - 国内云，经常有优惠
-图片视频处理工具- [Github Pages](https://pages.github.com/) - 免费
+- [Github Pages](https://pages.github.com/) - 免费
 [Lunalisa](https://luna-lisa.art) - AI 图像工作台，可根据文字提示和获准的参考图生成与调整产品视觉内容。
 - [Cloudflare Pages](https://developers.cloudflare.com/pages/)
 - [AirCode](https://aircode.io/) - 字节出品


### PR DESCRIPTION
## Tool submission

**Tool:** [Lunalisa](https://luna-lisa.art)
**Category:** 图片视频处理工具

Lunalisa is an AI image workspace for generating and refining product visuals with prompts and permitted reference images. The official site is publicly accessible.

The entry follows the existing list format. I am associated with the submitted project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Lunalisa to the image and video tools section of the README so it appears alongside similar tools. The entry links to the public site and describes it as an image workspace for generating and refining product visuals from prompts and permitted reference images.

<sup>Written for commit 821634ca0283fc354147f2f506143a6cc8ac687b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

