### PR TITLE
Add XiuRouter to AI resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@
 
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
+- [XiuRouter](https://router.xiu.ai/) - (按量付费) 一个 API 服务接入 Claude、GPT、Gemini 等主流模型，提供 OpenAI、Anthropic 与 Gemini 原生协议入口、范围可控的 API 密钥、逐请求用量与费用记录，以及 14 个开发工具和 Agent 接入；部分模型与服务档位相较供应商参考价最高可省 90%+。
 
 ### 其他工具
 

--- a/README_en.md
+++ b/README_en.md
@@ -406,6 +406,7 @@ Collect the latest and most practical free tools and resources in the field of i
 ### AI Resources
 
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0, open-source/self-hosted) Multi-agent orchestrator that runs Claude Code, Codex CLI, Gemini CLI, OpenHands, Cursor, Aider, and 31 other CLI coding agents in parallel git worktrees. Deterministic Python scheduler, file-based state, MCP server, quality gates, cost tracking.
+- [XiuRouter](https://router.xiu.ai/) - (Usage-based) One API service for Claude, GPT, Gemini, and other leading models, with native OpenAI, Anthropic, and Gemini protocol endpoints, scoped API keys, per-request usage and cost records, and setup for 14 developer and agent tools; selected models and service tiers can save 90%+ versus provider reference prices.
 
 ### Other Tools
 


### PR DESCRIPTION
## What changed

- Added XiuRouter to `AI 资源` in `README.md`.
- Added the matching English entry to `AI Resources` in `README_en.md`.

## Why it fits

XiuRouter is a developer-facing, usage-based model API service for applications and AI agents. It provides protocol-specific OpenAI, Anthropic, and Gemini endpoints, scoped API keys, per-request usage and cost records, and setup guidance for 14 developer and agent tools.

The entry also qualifies the pricing claim: only selected models and service tiers can save 90%+ versus provider reference prices.

## Verification

- Confirmed the repository and its open/closed PRs contain no existing XiuRouter or `router.xiu.ai` entry.
- Confirmed `https://router.xiu.ai/` returns HTTP 200.
- Confirmed one XiuRouter entry exists in each README.
- Ran `git diff --check`.

Disclosure: I am affiliated with XiuRouter and XiuLab Inc. The submission was prepared with AI assistance and reviewed against the current public product pages.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds XiuRouter to the AI resources lists in `README.md` and `README_en.md` so users can find it alongside similar developer tools.

- XiuRouter is a usage-based API service with OpenAI, Anthropic, and Gemini protocol endpoints, scoped API keys, per-request usage and cost records, and setup docs for 14 developer tools.
- The README entry qualifies the 90%+ savings claim as applying only to selected models and service tiers.
- Disclosure: I am affiliated with XiuRouter and XiuLab Inc.

<sup>Written for commit 3eb1c700428a742fa01c58c230a6efe72a7e1783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

