### PR TITLE
添加 MailKite SaaS Starter（开源 Next.js SaaS 模板）到 Web 开发框架或模板

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 - [Opensaas](https://opensaas.sh/) - React + Node.js。集成了登录、支付（stripe）、邮件、AI 功能
 - [SaaS-Boilerplate](https://react-saas.com/) - 一款开源的 SaaS 模板，非常适合构建自己的 SaaS 应用
 - [nextjs subscription payments](https://subscription-payments.vercel.app/) - Vercel 开源的，支付采用的是 Stripe
+- [MailKite SaaS Starter](https://github.com/mailkite/saas-startup) - (免费) 基于 Next.js 15 的开源 SaaS 模板（MIT），登录功能内置在应用里（Google/GitHub OAuth + 邮箱密码，无需 Clerk/Auth0/Supabase 账号），集成了 Stripe 订阅、团队、Postgres/Drizzle
 - [boilerplatelist](https://boilerplatelist.com/) - 超过 130 个最佳 SaaS 样板和入门套件，并提供了评估和选择最适合项目需求的 SaaS 样板的指导
 - [Taxonomy](https://github.com/shadcn-ui/taxonomy) - 基于 Next.js 13 和 React 18 构建的开源 Web 应用实验项目
 - [unibest](https://github.com/codercup/unibest) - unibest 是由 uniapp + Vue3 + Ts + Vite4 + UnoCss + UniUI 驱动的跨端快速启动模板

--- a/README_en.md
+++ b/README_en.md
@@ -70,6 +70,7 @@ Collect the latest and most practical free tools and resources in the field of i
 - [SupaStarter](https://supastarter.dev) - (Paid) Offers both Next.js and Nuxt templates, feature-rich.
 - [SaaS-Boilerplate](https://react-saas.com/) - An open-source SaaS template, perfect for building your own SaaS application.
 - [nextjs subscription payments](https://subscription-payments.vercel.app/) - Open-sourced by Vercel, uses Stripe for payments.
+- [MailKite SaaS Starter](https://github.com/mailkite/saas-startup) - (Free) Open-source Next.js 15 SaaS starter (MIT) with auth built into the app (Google/GitHub OAuth + email/password, no Clerk/Auth0/Supabase account), Stripe subscriptions, teams, and Postgres/Drizzle.
 - [boilerplatelist](https://boilerplatelist.com/) - Over 130 best SaaS boilerplates and starter kits, with guidance on evaluating and selecting the best SaaS boilerplate for your project needs.
 - [Taxonomy](https://github.com/shadcn-ui/taxonomy) - An open-source web application experiment built with Next.js 13 and React 18.
 - [unibest](https://github.com/codercup/unibest) - A cross-platform quick-start template powered by uniapp + Vue3 + Ts + Vite4 + UnoCss + UniUI.


### PR DESCRIPTION
在「Web 开发框架或模板」分类中添加 **MailKite SaaS Starter**（中英文 README 同步更新，紧跟 nextjs subscription payments 之后）。

- 链接：https://github.com/mailkite/saas-startup（MIT 开源，免费）
- 在线演示：https://saas-startup.mailkite.dev
- 说明：基于 Next.js 15 的 SaaS 模板。与其它模板不同的是，登录功能直接内置在应用里（Google/GitHub OAuth + 邮箱密码），不需要注册 Clerk/Auth0/Supabase 等第三方认证服务；同时集成了 Stripe 订阅、团队、Postgres/Drizzle 和深色优先的 UI。

格式遵循贡献准则：`[工具名称](链接) - 简短描述`，并按本分类惯例标注了「(免费)」。

声明：我是该模板的维护者（MailKite）。项目还比较新，如果您希望等它有更多使用者后再收录，直接关闭即可，完全理解。

---

Adds **MailKite SaaS Starter** to "Web 开发框架或模板 / Web Framework" in both READMEs (right after nextjs subscription payments). MIT, free; Next.js 15 SaaS starter whose auth runs in-app (no Clerk/Auth0/Supabase account), plus Stripe subscriptions, teams, Postgres/Drizzle. Maintainer disclosure: this is our project — happy to adjust wording or close if it doesn't fit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MailKite SaaS Starter to the "Web 开发框架或模板" section in both `README.md` and `README_en.md`, right after nextjs subscription payments.

The new entry lists it as a free (MIT) Next.js 15 SaaS starter with auth built into the app (no Clerk/Auth0/Supabase account needed), plus Stripe subscriptions, teams, and Postgres/Drizzle.

The contributor discloses they maintain the project and are open to adjusting wording or closing the PR if it doesn't fit.

<sup>Written for commit 9f72023c913b0f8483aab1c25686dbebacca99e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

