### PR TITLE
添加 AI Novel Writer 到 AI 资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@
 
 ### AI 资源
 
+- [AI Novel Writer](https://github.com/EthanYoQ/AI-Novel-Writer) - (免费开源/本地优先) 面向小说作者的桌面创作工作台，把人物、世界观、大纲、章节、审稿和修订放在同一流程中；支持 Windows、macOS 和 Ollama。
+
 - [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - (免费开源/自部署) AI Agent 编排平台，并行运行 Claude Code、Codex CLI、Gemini CLI、Aider、OpenCode，内置 Kanban 任务管理 + Git worktree 隔离 + MCP Server。支持 GitHub/GitLab/**Gitee**，BYOK 模式用户自带 API key 无平台费。
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0 开源/自部署) 多 Agent 编排器，协调 Claude Code、Codex CLI、Gemini CLI、OpenHands、Cursor、Aider 等 37 个 CLI 编程 Agent 在并行 git worktree 中工作。确定性 Python 调度器（编排零 LLM token），文件状态、MCP server、质量门、成本追踪。
 

--- a/README_en.md
+++ b/README_en.md
@@ -405,6 +405,8 @@ Collect the latest and most practical free tools and resources in the field of i
 
 ### AI Resources
 
+- [AI Novel Writer](https://github.com/EthanYoQ/AI-Novel-Writer) - (Free and open-source/local-first) Desktop fiction-writing workspace that keeps characters, worldbuilding, outlines, chapters, review, and revision in one workflow; supports Windows, macOS, and Ollama.
+
 - [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - (Apache 2.0, open-source/self-hosted) Multi-agent orchestrator that runs Claude Code, Codex CLI, Gemini CLI, OpenHands, Cursor, Aider, and 31 other CLI coding agents in parallel git worktrees. Deterministic Python scheduler, file-based state, MCP server, quality gates, cost tracking.
 
 ### Other Tools


### PR DESCRIPTION
## 说明

在中英文 `AI 资源` 中加入 AI Novel Writer。它是一款免费开源、本地优先的桌面小说创作工作台，把人物、世界观、大纲、章节、审稿和修订放在同一流程中，支持 Windows、macOS 和 Ollama。

我是项目作者。链接直达 GitHub 开源仓库，不含追踪参数。本申请使用 AI 协助准备，并由作者核对产品事实。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AI Novel Writer to the AI Resources sections in both the Chinese and English README files.

The tool is a free, open-source, local-first desktop fiction-writing workspace that supports Windows, macOS, and Ollama.

<sup>Written for commit 7113d7a1cd7b35e513217912ca9285e9baae3d77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yaolifeng0629/Awesome-independent-tools/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

